### PR TITLE
feat: add end-to-end testing setup with Maestro

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,6 +7,7 @@ jobs:
         runs-on: macos-latest
         env:
             CI: true
+            MAESTRO_CLI_NO_ANALYTICS: true
         steps:
             - name: Checkout repo
               uses: actions/checkout@v4
@@ -147,6 +148,11 @@ jobs:
                   echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
                   sudo udevadm control --reload-rules
                   sudo udevadm trigger --name-match=kvm
+            - name: Free up disk space
+              run: |
+                  sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/share/boost
+                  sudo rm -rf $ANDROID_HOME/ndk || true
+                  docker system prune -af || true
 
             - name: Build Debug APK
               run: |
@@ -159,7 +165,7 @@ jobs:
                   target: google_apis
                   arch: x86_64
                   disable-animations: true
-                  emulator-options: "-no-snapshot -no-boot-anim -no-window -gpu swiftshader_indirect -memory 4096 -cores 4"
+                  emulator-options: "-no-snapshot -no-boot-anim -no-window -gpu swiftshader_indirect -memory 2048 -cores 1"
                   script: mkdir -p e2e/reports && npm run e2e:test && pkill -f "Metro" || true
 
             - name: Upload test results

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,20 +20,29 @@ jobs:
             - name: Install dependencies
               run: npm ci
 
-            - name: Install Expo CLI
-              run: npm install -g expo-cli
+            - name: Install Maestro
+              run: |
+                  curl -Ls "https://get.maestro.mobile.dev" | bash
+                  echo "$HOME/.maestro/bin" >> $GITHUB_PATH
 
             - name: Install applesimutils
               run: |
                   brew tap wix/brew
                   brew install applesimutils
+            - name: Boot iOS Simulator
+              run: |
+                  DEVICE_NAME="iPhone 17"
+                  OS_VERSION=$(xcrun simctl list runtimes | grep "iOS 26" | head -n 1 | awk -F'[()]' '{print $2}')
+                  xcrun simctl bootstatus "$DEVICE_NAME" || xcrun simctl boot "$DEVICE_NAME"
+                  xcrun simctl bootstatus "$DEVICE_NAME" -b
+                  xcrun simctl list devices | grep Booted
 
-            - name: Prebuild
-              run: npm run prebuild
-
-            # Build iOS and Android apps for E2E
-            - name: Build iOS for Detox
-              run: npm run e2e:build:ios
+            - name: Build iOS app
+              run: |
+                  cd ios
+                  pod install
+                  cd ..
+                  npm run build:ios
 
             # Start Metro bundler in background
             - name: Start Metro bundler
@@ -43,8 +52,22 @@ jobs:
             - name: Wait for Metro
               run: sleep 20
 
-            - name: Run iOS Detox tests
-              run: npm run e2e:test:ios
+            - name: Run iOS Maestro tests
+              run: npm run e2e:test
+
+            - name: Upload test results
+              uses: actions/upload-artifact@v4
+              if: always()
+              with:
+                  name: e2e-test-results-ios
+                  path: e2e/reports/ios/
+
+            - name: Upload screenshots
+              uses: actions/upload-artifact@v4
+              if: failure()
+              with:
+                  name: e2e-screenshots-ios
+                  path: e2e/reports/screenshots/
 
     # TODO: Fix android e2e tests (No space left on device)
     # android_e2e:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -185,9 +185,3 @@ jobs:
                   name: e2e-test-results-android
                   path: e2e/reports/
 
-            - name: Upload screenshots
-              uses: actions/upload-artifact@v4
-              if: failure()
-              with:
-                  name: e2e-screenshots-android
-                  path: e2e/reports/screenshots/

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -155,7 +155,7 @@ jobs:
                   target: google_apis
                   arch: x86_64
                   disable-animations: true
-                  emulator-options: "-no-snapshot -no-boot-anim -no-window -gpu swiftshader_indirect -memory 2048 -cores 1"
+                  emulator-options: "-no-snapshot -no-boot-anim -no-window -gpu swiftshader_indirect -memory 2048 -cores 2"
                   script: npm start & METRO_PID=$! && cd android && ./gradlew assembleDebug && cd .. && adb install -r android/app/build/outputs/apk/debug/app-debug.apk && npm run e2e:test && pkill -f "Metro" || true
 
             - name: Upload test results

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -71,6 +71,10 @@ jobs:
                   METRO_PID=$!
                   sleep 10
 
+                  # Run the app
+                  xcrun simctl launch booted mytestlibrary.example || true
+                  sleep 10
+
                   # Run the tests
                   npm run e2e:test
 
@@ -167,7 +171,7 @@ jobs:
                   arch: x86_64
                   disable-animations: true
                   emulator-options: "-no-snapshot -no-boot-anim -no-window -gpu swiftshader_indirect -memory 2048 -cores 1"
-                  script: adb install -r android/app/build/outputs/apk/debug/app-debug.apk && mkdir -p e2e/reports && npm run e2e:test && pkill -f "Metro" || true
+                  script: cd android && ./gradlew assembleDebug && cd .. && adb install -r android/app/build/outputs/apk/debug/app-debug.apk && mkdir -p e2e/reports && npm run e2e:test && pkill -f "Metro" || true
 
             - name: Upload test results
               uses: actions/upload-artifact@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -114,6 +114,12 @@ jobs:
                   node-version: 20
                   cache: "npm"
 
+            - name: Set up JDK
+              uses: actions/setup-java@v4
+              with:
+                  distribution: zulu
+                  java-version: 21
+
             - name: Install dependencies
               run: npm ci
 
@@ -156,7 +162,7 @@ jobs:
                   arch: x86_64
                   disable-animations: true
                   emulator-options: "-no-snapshot -no-boot-anim -no-window -gpu swiftshader_indirect -memory 2048 -cores 2"
-                  script: npm start & METRO_PID=$! && cd android && ./gradlew assembleDebug && cd .. && adb install -r android/app/build/outputs/apk/debug/app-debug.apk && npm run e2e:test && pkill -f "Metro" || true
+                  script: cd android && ./gradlew assembleDebug && cd .. && adb install -r android/app/build/outputs/apk/debug/app-debug.apk && npm start & METRO_PID=$! && sleep 10 && adb shell am start -n mytestlibrary.example/.MainActivity || true && npm run e2e:test && pkill -f "Metro" || true
 
             - name: Upload test results
               uses: actions/upload-artifact@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,10 +31,7 @@ jobs:
                   brew install applesimutils
             - name: Boot iOS Simulator
               run: |
-                  DEVICE_NAME="iPhone 17"
-                  OS_VERSION=$(xcrun simctl list runtimes | grep "iOS 26" | head -n 1 | awk -F'[()]' '{print $2}')
-                  xcrun simctl bootstatus "$DEVICE_NAME" || xcrun simctl boot "$DEVICE_NAME"
-                  xcrun simctl bootstatus "$DEVICE_NAME" -b
+                  xcrun simctl bootstatus "iPhone 17 Pro" || xcrun simctl boot "iPhone 17 Pro"
                   xcrun simctl list devices | grep Booted
 
             - name: Build iOS app
@@ -69,86 +66,80 @@ jobs:
                   name: e2e-screenshots-ios
                   path: e2e/reports/screenshots/
 
-    # TODO: Fix android e2e tests (No space left on device)
-    # android_e2e:
-    #     runs-on: ubuntu-latest
-    #     env:
-    #         EXPO_NO_WAIT: true
-    #         CI: true
+    android_e2e:
+        runs-on: ubuntu-latest
+        env:
+            EXPO_NO_WAIT: true
+            CI: true
 
-    #     steps:
-    #         - name: Checkout repo
-    #           uses: actions/checkout@v3
+        steps:
+            - name: Checkout repo
+              uses: actions/checkout@v3
 
-    #         - name: Set up Node.js
-    #           uses: actions/setup-node@v3
-    #           with:
-    #               node-version: 20
+            - name: Set up Node.js
+              uses: actions/setup-node@v3
+              with:
+                  node-version: 20
 
-    #         - name: Install dependencies
-    #           run: npm ci
+            - name: Install dependencies
+              run: npm ci
 
-    #         - name: Install Expo CLI
-    #           run: npm install -g expo-cli
+            - name: Install Maestro
+              run: |
+                  curl -Ls "https://get.maestro.mobile.dev" | bash
+                  echo "$HOME/.maestro/bin" >> $GITHUB_PATH
 
-    #         - name: Android SDK
-    #           uses: android-actions/setup-android@v3
+            - name: Android SDK
+              uses: android-actions/setup-android@v3
 
-    #         - name: Setup NDK
-    #           uses: nttld/setup-ndk@v1
-    #           with:
-    #               ndk-version: r26d
+            - name: Setup NDK
+              uses: nttld/setup-ndk@v1
+              with:
+                  ndk-version: r26d
 
-    #         - name: Prebuild
-    #           run: npm run prebuild
+            - name: Prebuild
+              run: npm run assets
 
-    #         - name: Start Metro bundler
-    #           run: npx expo start --dev-client --port 8081 &
+            - name: Start Metro bundler
+              run: npx expo start --dev-client --port 8081 &
 
-    #         - name: Wait for Metro
-    #           run: |
-    #               for i in {1..30}; do
-    #                   if nc -z localhost 8081; then
-    #                   echo "Metro is up!"
-    #                   break
-    #                   fi
-    #                   echo "Waiting for Metro..."
-    #                   sleep 2
-    #               done
+            - name: Wait for Metro
+              run: |
+                  for i in {1..30}; do
+                      if nc -z localhost 8081; then
+                      echo "Metro is up!"
+                      break
+                      fi
+                      echo "Waiting for Metro..."
+                      sleep 2
+                  done
 
-    #         - name: Enable KVM (faster emulator)
-    #           run: |
-    #               echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-    #               sudo udevadm control --reload-rules
-    #               sudo udevadm trigger --name-match=kvm
+            - name: Enable KVM (faster emulator)
+              run: |
+                  echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+                  sudo udevadm control --reload-rules
+                  sudo udevadm trigger --name-match=kvm
 
-    #         - name: Clean workspace
-    #           run: |
-    #               echo "Cleaning unused caches..."
-    #               sudo rm -rf $HOME/.gradle/caches/
-    #               sudo rm -rf $HOME/.android/build-cache/
-    #               sudo rm -rf android/app/build/
-    #               sudo rm -rf /tmp/*
-    #               sudo rm -rf /usr/local/lib/android/sdk/system-images
+            - name: Build Android for Detox
+              uses: reactivecircus/android-emulator-runner@v2
+              with:
+                  api-level: 29
+                  target: google_apis
+                  arch: x86_64
+                  disable-animations: true
+                  emulator-options: "-no-snapshot -no-boot-anim -no-window -gpu swiftshader_indirect -memory 4096 -cores 4"
+                  script: npm run e2e:test
 
-    #         - name: Build Android for Detox
-    #           uses: reactivecircus/android-emulator-runner@v2
-    #           with:
-    #               api-level: 29
-    #               target: google_apis
-    #               arch: x86_64
-    #               disable-animations: true
-    #               disk-size: 2048M
-    #               emulator-options: "-no-snapshot -no-boot-anim -no-window -gpu swiftshader_indirect -memory 4096 -cores 4"
-    #               script: npm run e2e:build:android
+            - name: Upload test results
+              uses: actions/upload-artifact@v4
+              if: always()
+              with:
+                  name: e2e-test-results-android
+                  path: e2e/reports/android/
 
-    #         - name: Run Android Detox tests
-    #           uses: reactivecircus/android-emulator-runner@v2
-    #           with:
-    #               api-level: 29
-    #               target: google_apis
-    #               arch: x86_64
-    #               disable-animations: true
-    #               disk-size: 2048M
-    #               emulator-options: "-no-snapshot -no-boot-anim -no-window -gpu swiftshader_indirect -memory 4096 -cores 4"
-    #               script: npm run e2e:build:android
+            - name: Upload screenshots
+              uses: actions/upload-artifact@v4
+              if: failure()
+              with:
+                  name: e2e-screenshots-android
+                  path: e2e/reports/screenshots/

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -43,6 +43,9 @@ jobs:
             - name: Wait for Metro
               run: sleep 20
 
+            - name: Boot iOS Simulator
+              run: xcrun simctl boot "iPhone 16"
+
             - name: Run iOS Maestro tests
               run: npm run e2e:test
 
@@ -113,7 +116,13 @@ jobs:
                   sudo udevadm control --reload-rules
                   sudo udevadm trigger --name-match=kvm
 
-            - name: Build Android for Detox
+            - name: Build Debug APK
+              run: |
+                  cd android
+                  ./gradlew assembleDebug
+                  cd ..
+
+            - name: Test Android with Maestro
               uses: reactivecircus/android-emulator-runner@v2
               with:
                   api-level: 29
@@ -121,7 +130,7 @@ jobs:
                   arch: x86_64
                   disable-animations: true
                   emulator-options: "-no-snapshot -no-boot-anim -no-window -gpu swiftshader_indirect -memory 4096 -cores 4"
-                  script: npm run e2e:test
+                  script: adb devices && adb install -r android/app/build/outputs/apk/debug/app-debug.apk && adb shell input keyevent 82 && sleep 10 && npm run e2e:test
 
             - name: Upload test results
               uses: actions/upload-artifact@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -162,7 +162,7 @@ jobs:
                   arch: x86_64
                   disable-animations: true
                   emulator-options: "-no-snapshot -no-boot-anim -no-window -gpu swiftshader_indirect -memory 2048 -cores 2"
-                  script: cd android && ./gradlew assembleDebug && cd .. && adb install -r android/app/build/outputs/apk/debug/app-debug.apk && npm start & METRO_PID=$! && sleep 10 && adb shell am start -n mytestlibrary.example/.MainActivity || true && npm run e2e:test && pkill -f "Metro" || true
+                  script: npm start & METRO_PID=$! && cd android && ./gradlew assembleDebug && cd .. && adb install -r android/app/build/outputs/apk/debug/app-debug.apk && npm run e2e:test && pkill -f "Metro" || true
 
             - name: Upload test results
               uses: actions/upload-artifact@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -96,6 +96,7 @@ jobs:
         runs-on: ubuntu-latest
         env:
             CI: true
+            MAESTRO_CLI_NO_ANALYTICS: true
 
         steps:
             - name: Checkout repo
@@ -166,7 +167,7 @@ jobs:
                   arch: x86_64
                   disable-animations: true
                   emulator-options: "-no-snapshot -no-boot-anim -no-window -gpu swiftshader_indirect -memory 2048 -cores 1"
-                  script: mkdir -p e2e/reports && npm run e2e:test && pkill -f "Metro" || true
+                  script: adb install -r android/app/build/outputs/apk/debug/app-debug.apk && mkdir -p e2e/reports && npm run e2e:test && pkill -f "Metro" || true
 
             - name: Upload test results
               uses: actions/upload-artifact@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -38,7 +38,7 @@ jobs:
 
             # Start Metro bundler in background
             - name: Start Metro bundler
-              run: npm run start
+              run: npm run start &
 
             # Give Metro a few seconds to boot before launching Detox
             - name: Wait for Metro
@@ -95,7 +95,7 @@ jobs:
               run: npm run assets
 
             - name: Start Metro bundler
-              run: npm run start
+              run: npm run start &
 
             - name: Wait for Metro
               run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,7 +6,6 @@ jobs:
     ios_e2e:
         runs-on: macos-latest
         env:
-            EXPO_NO_WAIT: true
             CI: true
         steps:
             - name: Checkout repo
@@ -29,10 +28,6 @@ jobs:
               run: |
                   brew tap wix/brew
                   brew install applesimutils
-            - name: Boot iOS Simulator
-              run: |
-                  xcrun simctl bootstatus "iPhone 17 Pro" || xcrun simctl boot "iPhone 17 Pro"
-                  xcrun simctl list devices | grep Booted
 
             - name: Build iOS app
               run: |
@@ -43,7 +38,7 @@ jobs:
 
             # Start Metro bundler in background
             - name: Start Metro bundler
-              run: npx expo start --dev-client --port 8081 &
+              run: npm run start
 
             # Give Metro a few seconds to boot before launching Detox
             - name: Wait for Metro
@@ -69,7 +64,6 @@ jobs:
     android_e2e:
         runs-on: ubuntu-latest
         env:
-            EXPO_NO_WAIT: true
             CI: true
 
         steps:
@@ -101,7 +95,7 @@ jobs:
               run: npm run assets
 
             - name: Start Metro bundler
-              run: npx expo start --dev-client --port 8081 &
+              run: npm run start
 
             - name: Wait for Metro
               run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -150,7 +150,7 @@ jobs:
 
             - name: Build Debug APK
               run: |
-                  npm run build:android:x86
+                  npm run build:android
 
             - name: Test Android with Maestro
               uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,7 +44,15 @@ jobs:
               run: sleep 20
 
             - name: Boot iOS Simulator
-              run: xcrun simctl boot "iPhone 16"
+              run: |
+                  xcrun simctl boot "iPhone 16"
+                     xcrun simctl list devices | grep Booted
+                  sleep 10
+
+            - name: Install app to simulator
+              run: |
+                  xcrun simctl install booted ios/build/Build/Products/Debug-iphonesimulator/MyTestLibraryExample.app
+                  xcrun simctl launch booted mytestlibrary.example || echo "App launched manually later"
 
             - name: Run iOS Maestro tests
               run: npm run e2e:test
@@ -130,7 +138,7 @@ jobs:
                   arch: x86_64
                   disable-animations: true
                   emulator-options: "-no-snapshot -no-boot-anim -no-window -gpu swiftshader_indirect -memory 4096 -cores 4"
-                  script: adb devices && adb install -r android/app/build/outputs/apk/debug/app-debug.apk && adb shell input keyevent 82 && sleep 10 && npm run e2e:test
+                  script: npm run e2e:test
 
             - name: Upload test results
               uses: actions/upload-artifact@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -34,7 +34,6 @@ jobs:
                   cd ios
                   pod install
                   cd ..
-                  npm run build:ios
 
             # Start Metro bundler in background
             - name: Start Metro bundler

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,6 +8,7 @@ jobs:
         env:
             CI: true
             MAESTRO_CLI_NO_ANALYTICS: true
+        timeout-minutes: 30
         steps:
             - name: Checkout repo
               uses: actions/checkout@v4
@@ -101,6 +102,7 @@ jobs:
         env:
             CI: true
             MAESTRO_CLI_NO_ANALYTICS: true
+        timeout-minutes: 30
 
         steps:
             - name: Checkout repo
@@ -154,7 +156,7 @@ jobs:
                   arch: x86_64
                   disable-animations: true
                   emulator-options: "-no-snapshot -no-boot-anim -no-window -gpu swiftshader_indirect -memory 2048 -cores 1"
-                  script: npm start & METRO_PID=$! && cd android && ./gradlew assembleDebug && cd .. && adb install -r android/app/build/outputs/apk/debug/app-debug.apk && mkdir -p e2e/reports && npm run e2e:test && pkill -f "Metro" || true
+                  script: npm start & METRO_PID=$! && cd android && ./gradlew assembleDebug && cd .. && adb install -r android/app/build/outputs/apk/debug/app-debug.apk && adb shell am start -n mytestlibrary.example/.MainActivity || true && sleep 10 && npm run e2e:test && pkill -f "Metro" || true
 
             - name: Upload test results
               uses: actions/upload-artifact@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -131,23 +131,6 @@ jobs:
             - name: Prebuild
               run: npm run assets
 
-            - name: Start Metro bundler
-              run: |
-                  npm start &
-                  METRO_PID=$!
-                  echo "METRO_PID=$METRO_PID" >> $GITHUB_ENV
-
-            - name: Wait for Metro
-              run: |
-                  for i in {1..30}; do
-                      if nc -z localhost 8081; then
-                          echo "Metro is up!"
-                          break
-                      fi
-                      echo "Waiting for Metro..."
-                      sleep 2
-                  done
-
             - name: Enable KVM (faster emulator)
               run: |
                   echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
@@ -171,7 +154,7 @@ jobs:
                   arch: x86_64
                   disable-animations: true
                   emulator-options: "-no-snapshot -no-boot-anim -no-window -gpu swiftshader_indirect -memory 2048 -cores 1"
-                  script: cd android && ./gradlew assembleDebug && cd .. && adb install -r android/app/build/outputs/apk/debug/app-debug.apk && mkdir -p e2e/reports && npm run e2e:test && pkill -f "Metro" || true
+                  script: npm start & METRO_PID=$! && cd android && ./gradlew assembleDebug && cd .. && adb install -r android/app/build/outputs/apk/debug/app-debug.apk && mkdir -p e2e/reports && npm run e2e:test && pkill -f "Metro" || true
 
             - name: Upload test results
               uses: actions/upload-artifact@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -158,11 +158,25 @@ jobs:
               uses: reactivecircus/android-emulator-runner@v2
               with:
                   api-level: 29
-                  target: google_apis
+                  target: default
                   arch: x86_64
                   disable-animations: true
                   emulator-options: "-no-snapshot -no-boot-anim -no-window -gpu swiftshader_indirect -memory 2048 -cores 2"
-                  script: npm start & METRO_PID=$! && cd android && ./gradlew assembleDebug && cd .. && adb install -r android/app/build/outputs/apk/debug/app-debug.apk && npm run e2e:test && pkill -f "Metro" || true
+                  script: |
+                      # Start Metro bundler for tests
+                      npm start & METRO_PID=$!
+
+                      # Build and install the app
+                      cd android && ./gradlew assembleDebug && cd ..
+
+                      # Install the app
+                      adb install -r android/app/build/outputs/apk/debug/app-debug.apk
+
+                      # Run the tests
+                      npm run e2e:test
+
+                      # Clean up
+                      kill $METRO_PID 2>/dev/null || true && pkill -f "Metro" || true
 
             - name: Upload test results
               uses: actions/upload-artifact@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,12 +9,13 @@ jobs:
             CI: true
         steps:
             - name: Checkout repo
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Set up Node.js
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: 20
+                  cache: "npm"
 
             - name: Install dependencies
               run: npm ci
@@ -29,40 +30,63 @@ jobs:
                   brew tap wix/brew
                   brew install applesimutils
 
-            - name: Build iOS app
+            - name: Install CocoaPods dependencies
               run: |
                   cd ios
                   pod install
                   cd ..
 
-            # Start Metro bundler in background
-            - name: Start Metro bundler
-              run: npm run start &
-
-            # Give Metro a few seconds to boot before launching Detox
-            - name: Wait for Metro
-              run: sleep 20
-
             - name: Boot iOS Simulator
               run: |
+                  xcrun simctl shutdown all
                   xcrun simctl boot "iPhone 16"
-                     xcrun simctl list devices | grep Booted
+                  xcrun simctl list devices | grep Booted
                   sleep 10
 
-            - name: Install app to simulator
+            - name: Build and install iOS app
               run: |
-                  xcrun simctl install booted ios/build/Build/Products/Debug-iphonesimulator/MyTestLibraryExample.app
-                  xcrun simctl launch booted mytestlibrary.example || echo "App launched manually later"
+                  # Start Metro bundler in background
+                  npm start &
+                  METRO_PID=$!
+                  sleep 15
+
+                  # Build and run the app (this works)
+                  npm run ios &
+                  IOS_PID=$!
+                  sleep 60
+
+                  # Kill the processes but keep the app installed
+                  kill $METRO_PID 2>/dev/null || true
+                  kill $IOS_PID 2>/dev/null || true
+                  pkill -f "Metro" || true
+                  pkill -f "MyTestLibraryExample" || true
+
+                  # Verify app is installed
+                  xcrun simctl list apps booted | grep mytestlibrary.example
 
             - name: Run iOS Maestro tests
-              run: npm run e2e:test
+              run: |
+                  # Create reports directory
+                  mkdir -p e2e/reports
+
+                  # Start Metro bundler for tests
+                  npm start &
+                  METRO_PID=$!
+                  sleep 10
+
+                  # Run the tests
+                  npm run e2e:test
+
+                  # Clean up
+                  kill $METRO_PID 2>/dev/null || true
+                  pkill -f "Metro" || true
 
             - name: Upload test results
               uses: actions/upload-artifact@v4
               if: always()
               with:
                   name: e2e-test-results-ios
-                  path: e2e/reports/ios/
+                  path: e2e/reports/
 
             - name: Upload screenshots
               uses: actions/upload-artifact@v4
@@ -78,12 +102,13 @@ jobs:
 
         steps:
             - name: Checkout repo
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Set up Node.js
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: 20
+                  cache: "npm"
 
             - name: Install dependencies
               run: npm ci
@@ -105,14 +130,17 @@ jobs:
               run: npm run assets
 
             - name: Start Metro bundler
-              run: npm run start &
+              run: |
+                  npm start &
+                  METRO_PID=$!
+                  echo "METRO_PID=$METRO_PID" >> $GITHUB_ENV
 
             - name: Wait for Metro
               run: |
                   for i in {1..30}; do
                       if nc -z localhost 8081; then
-                      echo "Metro is up!"
-                      break
+                          echo "Metro is up!"
+                          break
                       fi
                       echo "Waiting for Metro..."
                       sleep 2
@@ -126,9 +154,7 @@ jobs:
 
             - name: Build Debug APK
               run: |
-                  cd android
-                  ./gradlew assembleDebug
-                  cd ..
+                  npm run build:android:x86
 
             - name: Test Android with Maestro
               uses: reactivecircus/android-emulator-runner@v2
@@ -138,14 +164,14 @@ jobs:
                   arch: x86_64
                   disable-animations: true
                   emulator-options: "-no-snapshot -no-boot-anim -no-window -gpu swiftshader_indirect -memory 4096 -cores 4"
-                  script: npm run e2e:test
+                  script: mkdir -p e2e/reports && npm run e2e:test && pkill -f "Metro" || true
 
             - name: Upload test results
               uses: actions/upload-artifact@v4
               if: always()
               with:
                   name: e2e-test-results-android
-                  path: e2e/reports/android/
+                  path: e2e/reports/
 
             - name: Upload screenshots
               uses: actions/upload-artifact@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,6 +17,12 @@ jobs:
                   node-version: 20
                   cache: "npm"
 
+            - name: Set up JDK
+              uses: actions/setup-java@v4
+              with:
+                  distribution: zulu
+                  java-version: 21
+
             - name: Install dependencies
               run: npm ci
 
@@ -45,24 +51,14 @@ jobs:
 
             - name: Build and install iOS app
               run: |
-                  # Start Metro bundler in background
-                  npm start &
-                  METRO_PID=$!
-                  sleep 15
+                  xcodebuild -scheme MyTestLibraryExample \
+                  -workspace ios/MyTestLibraryExample.xcworkspace \
+                  -configuration Debug \
+                  -sdk iphonesimulator \
+                  -derivedDataPath build \
+                  -arch arm64
 
-                  # Build and run the app (this works)
-                  npm run ios &
-                  IOS_PID=$!
-                  sleep 60
-
-                  # Kill the processes but keep the app installed
-                  kill $METRO_PID 2>/dev/null || true
-                  kill $IOS_PID 2>/dev/null || true
-                  pkill -f "Metro" || true
-                  pkill -f "MyTestLibraryExample" || true
-
-                  # Verify app is installed
-                  xcrun simctl list apps booted | grep mytestlibrary.example
+                  xcrun simctl install booted build/Build/Products/Debug-iphonesimulator/MyTestLibraryExample.app
 
             - name: Run iOS Maestro tests
               run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -156,7 +156,7 @@ jobs:
                   arch: x86_64
                   disable-animations: true
                   emulator-options: "-no-snapshot -no-boot-anim -no-window -gpu swiftshader_indirect -memory 2048 -cores 1"
-                  script: npm start & METRO_PID=$! && cd android && ./gradlew assembleDebug && cd .. && adb install -r android/app/build/outputs/apk/debug/app-debug.apk && adb shell am start -n mytestlibrary.example/.MainActivity || true && sleep 10 && npm run e2e:test && pkill -f "Metro" || true
+                  script: npm start & METRO_PID=$! && cd android && ./gradlew assembleDebug && cd .. && adb install -r android/app/build/outputs/apk/debug/app-debug.apk && npm run e2e:test && pkill -f "Metro" || true
 
             - name: Upload test results
               uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ web-build/
 expo-env.d.ts
 # @end expo-cli
 
+build/
 ios/build
 ios/.xcode.env.local
 ios/Pods

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ MoproReactNativeBindings/android/build/
 MoproReactNativeBindings/android/.gradle/
 MoproReactNativeBindings/android/.cxx/
 MoproReactNativeBindings/lib
+
+e2e/reports/

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,127 @@
+# E2E Tests for React Native Proof App
+
+This directory contains end-to-end (E2E) tests for the React Native cryptographic proof generation app using Maestro.
+
+## Test Structure
+
+- `tests/` - Contains individual test files
+    - `circom-proof-test.yaml` - Tests for Circom proof generation and verification
+- `maestro.yaml` - Global Maestro configuration
+- `reports/` - Test execution reports (generated automatically)
+
+## Prerequisites
+
+1. **Maestro CLI** - Install using:
+
+    ```bash
+    curl -Ls "https://get.maestro.mobile.dev" | bash
+    export PATH="$PATH":"$HOME/.maestro/bin"
+    ```
+
+2. **iOS Simulator** (for iOS tests):
+    - Xcode installed
+    - iOS Simulator running
+    - App built and installed
+
+3. **Android Emulator** (for Android tests):
+    - Android Studio installed
+    - Android Emulator running
+    - App built and installed
+
+## Running Tests
+
+### Run All Tests
+
+```bash
+# From project root
+npm run e2e:test
+```
+
+### Run Individual Tests
+
+```bash
+# Run specific test
+maestro test e2e/tests/circom-proof-test.yaml
+```
+
+### Run Tests with Different Configurations
+
+```bash
+# Run with custom device
+maestro test e2e/tests/ --device "iPhone 14 Pro"
+
+# Run with verbose output
+maestro test e2e/tests/ --verbose
+
+# Run and generate reports
+maestro test e2e/tests/ --format junit --output e2e/reports/
+```
+
+## Test Coverage
+
+The E2E tests cover:
+
+1. **App Launch** - Verifies app starts correctly
+2. **Tab Navigation** - Tests switching between Circom, Halo2, and Noir tabs
+3. **Input Validation** - Tests text input fields for each proof type
+4. **Proof Generation** - Tests proof generation functionality
+5. **Proof Verification** - Tests proof verification functionality
+6. **UI Elements** - Verifies all UI components are visible and interactive
+7. **Complete Workflow** - Tests end-to-end user journey
+
+## Test Data
+
+Tests use various input values to verify proof generation:
+
+- Circom: a=3, b=4 and a=5, b=6
+- Halo2: out=55 and out=89
+- Noir: a=7, b=8 and a=2, b=3
+
+## Troubleshooting
+
+### Common Issues
+
+1. **App not found**: Ensure the app is built and installed on the device/simulator
+2. **Element not found**: Check that testID attributes are correctly set in the app
+3. **Timeout errors**: Increase timeout values in maestro.yaml
+4. **Device not found**: Ensure simulator/emulator is running and accessible
+
+### Debug Mode
+
+Run tests in debug mode for detailed logging:
+
+```bash
+maestro test e2e/tests/ --debug
+```
+
+### Screenshots
+
+Screenshots are automatically taken on test failures and saved to `e2e/reports/screenshots/`
+
+## CI/CD Integration
+
+The tests are designed to run in CI/CD pipelines. Use the following commands:
+
+```bash
+# Install Maestro in CI
+curl -Ls "https://get.maestro.mobile.dev" | bash
+export PATH="$PATH":"$HOME/.maestro/bin"
+
+# Run tests
+maestro test e2e/tests/ --format junit --output e2e/reports/
+```
+
+## Adding New Tests
+
+1. Create a new `.yaml` file in the `tests/` directory
+2. Follow the Maestro YAML syntax
+3. Use existing testID attributes from the app
+4. Add the test to the test suite by running it individually first
+5. Update this README if needed
+
+## Test Maintenance
+
+- Update tests when UI changes
+- Add new test cases for new features
+- Remove obsolete tests
+- Keep test data realistic and varied

--- a/e2e/maestro.yaml
+++ b/e2e/maestro.yaml
@@ -1,0 +1,55 @@
+# Maestro E2E Test Configuration
+# This file contains global configuration for Maestro tests
+
+# Test suite configuration
+testSuite:
+    name: "React Native Proof App E2E Tests"
+    description: "End-to-end tests for the cryptographic proof generation React Native app"
+
+# Global test settings
+global:
+    # Timeout for individual actions (in milliseconds)
+    actionTimeout: 10000
+
+    # Timeout for assertions (in milliseconds)
+    assertionTimeout: 5000
+
+    # Screenshot settings
+    takeScreenshotOnFailure: true
+    takeScreenshotOnSuccess: false
+
+    # Logging level
+    logLevel: "INFO"
+
+# Device configuration
+device:
+    # iOS Simulator settings
+    ios:
+        deviceName: "iPhone 17"
+        osVersion: "26.0"
+
+    # Android Emulator settings
+    android:
+        deviceName: "Pixel_8_API_35"
+        osVersion: "14"
+
+# Test execution settings
+execution:
+    # Parallel execution settings
+    parallel: false
+    maxConcurrentTests: 1
+
+    # Retry settings
+    retryOnFailure: 2
+    retryDelay: 5000
+
+# Reporting settings
+reporting:
+    # Generate HTML reports
+    generateHtmlReport: true
+
+    # Generate JUnit XML reports for CI/CD
+    generateJunitReport: true
+
+    # Report output directory
+    outputDir: "./e2e/reports"

--- a/e2e/tests/circom-proof-test.yaml
+++ b/e2e/tests/circom-proof-test.yaml
@@ -1,0 +1,22 @@
+appId: mytestlibrary.example
+---
+- launchApp
+- assertVisible: "Circom Proof"
+- assertVisible: "Halo2 Proof"
+- assertVisible: "Noir Proof"
+
+# Test Circom Proof functionality
+- tapOn:
+      id: "circom-input-a"
+- eraseText
+- inputText: 5
+- tapOn:
+      id: "circom-input-b"
+- eraseText
+- inputText: 6
+- tapOn:
+      id: "circom-gen-proof-button"
+- tapOn:
+      id: "circom-verify-proof-button"
+- assertVisible: "true"
+- assertVisible: "[\"30\",\"5\"]"

--- a/e2e/tests/circom-proof-test.yaml
+++ b/e2e/tests/circom-proof-test.yaml
@@ -1,15 +1,12 @@
 appId: mytestlibrary.example
 ---
 - launchApp
-- runFlow:
-      when:
-          visible: "Circom Proof"
-          visible: "Halo2 Proof"
-          visible: "Noir Proof"
-      commands:
-         - assertVisible: "Circom Proof"
-         - assertVisible: "Halo2 Proof"
-         - assertVisible: "Noir Proof"
+- extendedWaitUntil:
+    visible: "Circom Proof"
+    timeout: 30000
+- assertVisible: "Circom Proof"
+- assertVisible: "Halo2 Proof"
+- assertVisible: "Noir Proof"
 
 # Test Circom Proof functionality
 - tapOn:

--- a/e2e/tests/circom-proof-test.yaml
+++ b/e2e/tests/circom-proof-test.yaml
@@ -4,10 +4,12 @@ appId: mytestlibrary.example
 - runFlow:
       when:
           visible: "Circom Proof"
+          visible: "Halo2 Proof"
+          visible: "Noir Proof"
       commands:
          - assertVisible: "Circom Proof"
-- assertVisible: "Halo2 Proof"
-- assertVisible: "Noir Proof"
+         - assertVisible: "Halo2 Proof"
+         - assertVisible: "Noir Proof"
 
 # Test Circom Proof functionality
 - tapOn:

--- a/e2e/tests/circom-proof-test.yaml
+++ b/e2e/tests/circom-proof-test.yaml
@@ -1,6 +1,9 @@
 appId: mytestlibrary.example
 ---
 - launchApp
+- waitFor:
+      visible: "Circom Proof"
+      timeout: 60000 # wait up to 60s
 - assertVisible: "Circom Proof"
 - assertVisible: "Halo2 Proof"
 - assertVisible: "Noir Proof"
@@ -19,4 +22,4 @@ appId: mytestlibrary.example
 - tapOn:
       id: "circom-verify-proof-button"
 - assertVisible: "true"
-- assertVisible: "[\"30\",\"5\"]"
+- assertVisible: '["30","5"]'

--- a/e2e/tests/circom-proof-test.yaml
+++ b/e2e/tests/circom-proof-test.yaml
@@ -1,9 +1,10 @@
 appId: mytestlibrary.example
 ---
 - launchApp
-- waitForAnimationToEnd:
-      timeout: 60000 # wait up to 60s
-- assertVisible: "Circom Proof"
+- retry:
+      maxRetries: 10
+      commands:
+          - assertVisible: "Circom Proof"
 - assertVisible: "Halo2 Proof"
 - assertVisible: "Noir Proof"
 

--- a/e2e/tests/circom-proof-test.yaml
+++ b/e2e/tests/circom-proof-test.yaml
@@ -1,10 +1,11 @@
 appId: mytestlibrary.example
 ---
 - launchApp
-- retry:
-      maxRetries: 10
+- repeat:
+      while:
+          notVisible: "Circom Proof"
       commands:
-          - assertVisible: "Circom Proof"
+         - assertVisible: "Circom Proof"
 - assertVisible: "Halo2 Proof"
 - assertVisible: "Noir Proof"
 

--- a/e2e/tests/circom-proof-test.yaml
+++ b/e2e/tests/circom-proof-test.yaml
@@ -3,7 +3,7 @@ appId: mytestlibrary.example
 - launchApp
 - extendedWaitUntil:
     visible: "Circom Proof"
-    timeout: 30000
+    timeout: 60000
 - assertVisible: "Circom Proof"
 - assertVisible: "Halo2 Proof"
 - assertVisible: "Noir Proof"

--- a/e2e/tests/circom-proof-test.yaml
+++ b/e2e/tests/circom-proof-test.yaml
@@ -1,9 +1,9 @@
 appId: mytestlibrary.example
 ---
 - launchApp
-- repeat:
-      while:
-          notVisible: "Circom Proof"
+- runFlow:
+      when:
+          visible: "Circom Proof"
       commands:
          - assertVisible: "Circom Proof"
 - assertVisible: "Halo2 Proof"

--- a/e2e/tests/circom-proof-test.yaml
+++ b/e2e/tests/circom-proof-test.yaml
@@ -1,8 +1,7 @@
 appId: mytestlibrary.example
 ---
 - launchApp
-- waitFor:
-      visible: "Circom Proof"
+- waitForAnimationToEnd:
       timeout: 60000 # wait up to 60s
 - assertVisible: "Circom Proof"
 - assertVisible: "Halo2 Proof"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "android": "npm run assets && react-native run-android",
     "start": "react-native start",
     "build:android": "react-native build-android --extra-params \"--no-daemon --console=plain -PreactNativeArchitectures=arm64-v8a\"",
-    "build:ios": "react-native build-ios --mode Debug"
+    "build:ios": "react-native build-ios --mode Debug",
+    "e2e:test": "maestro test e2e/tests/",
+    "e2e:test:circom": "maestro test e2e/tests/circom-proof-test.yaml"
   },
   "dependencies": {
     "@react-native/new-app-screen": "0.81.4",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "start": "react-native start",
     "build:android": "react-native build-android --extra-params \"--no-daemon --console=plain -PreactNativeArchitectures=arm64-v8a\"",
     "build:ios": "react-native build-ios --mode Debug",
-    "e2e:test": "maestro test e2e/tests/",
-    "e2e:test:circom": "maestro test e2e/tests/circom-proof-test.yaml"
+    "e2e:test": "maestro test e2e/tests/ --debug-output=e2e/reports",
+    "e2e:test:circom": "maestro test e2e/tests/circom-proof-test.yaml --debug-output=e2e/reports"
   },
   "dependencies": {
     "@react-native/new-app-screen": "0.81.4",


### PR DESCRIPTION
- Introduced Maestro for E2E testing, including a global configuration file (maestro.yaml) and a sample test for Circom proof generation.
- Updated package.json with new scripts for running E2E tests.
- Enhanced GitHub Actions workflow to install Maestro, boot the iOS simulator, and run tests.
- Added README documentation for E2E tests, including prerequisites and usage instructions.
- Created a directory structure for test files and reports.