### PR TITLE
fix: use dynamic import for react-native-monorepo-config ESM module

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -1,17 +1,14 @@
 const path = require('path');
 const { getDefaultConfig } = require('@react-native/metro-config');
-const { withMetroConfig } = require('react-native-monorepo-config');
 
-const root = path.resolve(__dirname, './MoproReactNativeBindings');
+module.exports = (async () => {
+  const { withMetroConfig } = await import('react-native-monorepo-config');
 
-const config = getDefaultConfig(__dirname);
+  const config = getDefaultConfig(__dirname);
+  config.resolver.assetExts.push('zkey', 'bin', 'json', 'local');
 
-config.resolver.assetExts.push('zkey');
-config.resolver.assetExts.push('bin');
-config.resolver.assetExts.push('json');
-config.resolver.assetExts.push('local');
-
-module.exports = withMetroConfig(config, {
-  root,
-  dirname: __dirname,
-});
+  return withMetroConfig(config, {
+    root: path.resolve(__dirname, './MoproReactNativeBindings'),
+    dirname: __dirname,
+  });
+})();


### PR DESCRIPTION
## Summary
Fixed Metro bundler startup error caused by ESM/CommonJS module incompatibility

## Problem
Metro failed to start with error:
```
Error [ERR_REQUIRE_ESM]: require() of ES Module react-native-monorepo-config not supported
```

The `react-native-monorepo-config` package is an ES Module but was being loaded with `require()`, which is not supported in Node.js for ESM packages.

## Solution
- Replaced synchronous `require()` with async `import()` for ESM compatibility
- Used IIFE (Immediately Invoked Function Expression) pattern to handle async operation

## Changes
- metro.config.js: Refactored from named async function to async IIFE
- Combined multiple `.push()` calls into single operation